### PR TITLE
Refactor LSP modules

### DIFF
--- a/nvim/.config/nvim/lua/lsp/marksman.lua
+++ b/nvim/.config/nvim/lua/lsp/marksman.lua
@@ -1,7 +1,7 @@
 -- marksman LSP (https://github.com/artempyanykh/marksman)
-local util    = require('lspconfig.util')
+local util = require('lspconfig.util')
 
-require('lspconfig').marksman.setup({
+return {
     filetypes = { "markdown" },
     root_dir  = util.root_pattern(".git", ".marksman.toml"),
-})
+}

--- a/nvim/.config/nvim/lua/lsp/pyright.lua
+++ b/nvim/.config/nvim/lua/lsp/pyright.lua
@@ -1,1 +1,2 @@
-require('lspconfig').pyright.setup({})
+-- pyright LSP
+return {}

--- a/nvim/.config/nvim/lua/lsp/ruff.lua
+++ b/nvim/.config/nvim/lua/lsp/ruff.lua
@@ -1,5 +1,5 @@
 -- ruff LSP (https://docs.astral.sh/ruff/editors/settings/)
-require('lspconfig').ruff.setup {
+return {
     init_options = {
         settings = {
             lineLength = 80,


### PR DESCRIPTION
## Summary
- refactor pyright, marksman and ruff language servers
- return configuration tables instead of calling `setup`

## Testing
- `nvim --headless -c 'quit'`


------
https://chatgpt.com/codex/tasks/task_e_6840b6bfd118832385943128d13197bb