### PR TITLE
Fix tmux startup check in .bashrc

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -3,7 +3,9 @@
 
 # Automatically start or attach to a tmux session if not already in one.
 if [ -z "$TMUX" ]; then
-  tmux new-session -A -s default
+  if command -v tmux >/dev/null; then
+    tmux new-session -A -s default
+  fi
 fi
 
 # Include Homebrew paths


### PR DESCRIPTION
## Summary
- only start tmux session if `tmux` command is available

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840b6da0be48323a2461536dfbd4416