### PR TITLE
feat(nvim): hash host specific lazy lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,9 @@ Sessionx.vim
 .netrwhist
 *~
 
+## Lazy.nvim lock files
+nvim/.config/nvim/lazy-lock*
+
 
 ############
 # OS stuff #

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -1,9 +1,0 @@
-{
-  "cmp-nvim-lsp": { "branch": "main", "commit": "bd5a7d6db125d4654b50eeae9f5217f24bb22fd3" },
-  "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
-  "mason-lspconfig.nvim": { "branch": "main", "commit": "7f0bf635082bb9b7d2b37766054526a6ccafdb85" },
-  "mason.nvim": { "branch": "main", "commit": "7dc4facca9702f95353d5a1f87daf23d78e31c2a" },
-  "nvim-cmp": { "branch": "main", "commit": "b5311ab3ed9c846b585c0c15b7559be131ec4be9" },
-  "nvim-lspconfig": { "branch": "master", "commit": "45ff1914044de7dbd4cd85053dc09f47312a2f4d" },
-  "tokyonight.nvim": { "branch": "main", "commit": "057ef5d260c1931f1dffd0f052c685dcd14100a3" }
-}

--- a/nvim/.config/nvim/lua/lazy_setup.lua
+++ b/nvim/.config/nvim/lua/lazy_setup.lua
@@ -22,6 +22,19 @@ vim.g.mapleader = " "
 vim.g.maplocalleader = "\\"
 
 -- Run lazy.nvim setup
+local uv = vim.uv or vim.loop
+local config_path = vim.fn.stdpath("config")
+local salt_file = config_path .. "/lazy-lock.salt"
+local salt
+if vim.fn.filereadable(salt_file) == 1 then
+    salt = vim.fn.readfile(salt_file)[1]
+else
+    math.randomseed(uv.hrtime())
+    salt = vim.fn.sha256(tostring(math.random()))
+    vim.fn.writefile({ salt }, salt_file)
+end
+local hostname = uv.os_gethostname()
+local host_hash = vim.fn.sha256(hostname .. salt)
 require("lazy").setup({
     spec = {
         -- import plugins directory
@@ -31,4 +44,5 @@ require("lazy").setup({
     install = { colorscheme = { "tokyonight" } },
     -- automatically check for plugin updates
     checker = { enabled = true },
+    lockfile = config_path .. "/lazy-lock." .. host_hash .. ".json",
 })


### PR DESCRIPTION
## Summary
- ignore lazy lock artifacts
- hash hostname with persistent salt for lazy.nvim lockfile

## Testing
- `luajit -bl nvim/.config/nvim/lua/lazy_setup.lua >/tmp/lazy_setup.luac && ls /tmp/lazy_setup.luac`
- `HOME=/workspace ./manage.sh install`

------
https://chatgpt.com/codex/tasks/task_e_689d7f9e79188323a35f70fd12e6dd15