### PR TITLE
tmux: switch to native clipboard

### DIFF
--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -23,8 +23,6 @@ set -g @plugin 'tmux-plugins/tpm'
 # of hotkeys.
 set -g @plugin 'christoomey/vim-tmux-navigator'
 
-# Provides clipboard support
-set -g @plugin 'tmux-plugins/tmux-yank'
 
 # Run tpm
 run-shell '#{@confdir}/plugins/tpm/tpm'
@@ -51,6 +49,9 @@ bind C-Space send-prefix
 
 # Enable mouse support
 set -g mouse on
+
+# Use system clipboard for copy and paste
+set-option -s set-clipboard on
 
 # Add support for reloading tmux.conf
 bind R source-file "#{@confdir}/tmux.conf"
@@ -113,8 +114,6 @@ bind-key -T copy-mode-vi v  send -X begin-selection
 bind-key -T copy-mode-vi V  send -X begin-selection \; send -X select-line
 bind-key -T copy-mode-vi C-v send -X rectangle-toggle
 
-# Leave copy-mode automatically after y (and mouse drag)
-set -g @yank_action 'copy-pipe-and-cancel'
 
 # Vim-style pane selection
 bind h select-pane -L


### PR DESCRIPTION
## Summary
- remove tmux-yank plugin and rely on tmux's built-in clipboard
- enable system clipboard integration in tmux config

## Testing
- `HOME=/workspace ./manage.sh install` (aborted; warned missing tools)
- `tmux source-file ~/.config/tmux/tmux.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb4f6bd9483239ea1082da7cc1fb9