### PR TITLE
tmux: use external clipboard

### DIFF
--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -51,7 +51,8 @@ bind C-Space send-prefix
 set -g mouse on
 
 # Use system clipboard for copy and paste
-set-option -s set-clipboard on
+set-option -s set-clipboard external
+set-option -s buffer-limit 10
 
 # Add support for reloading tmux.conf
 bind R source-file "#{@confdir}/tmux.conf"


### PR DESCRIPTION
## Summary
- prevent tmux from importing every clipboard change by using external clipboard integration
- limit tmux buffer history to the ten most recent entries

## Testing
- `HOME=/workspace ./manage.sh install` (aborted after listing packages)
- `tmux source-file ~/.config/tmux/tmux.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a632748a888323908e1892fc933d56